### PR TITLE
Close #19 - use enums and javadoc on maven configuration objects so IDEs can discover options

### DIFF
--- a/petrify-maven-plugin/src/main/java/com/github/exabrial/petrify/maven/FossilConfig.java
+++ b/petrify-maven-plugin/src/main/java/com/github/exabrial/petrify/maven/FossilConfig.java
@@ -2,17 +2,84 @@ package com.github.exabrial.petrify.maven;
 
 import lombok.Data;
 
+/**
+ * Per-model configuration for the {@code fossilize} goal. Appears as {@code <fossil>} entries under
+ * the {@code <fossils>} list in a POM {@code <configuration>} block.
+ *
+ * <p>Example:
+ *
+ * <pre>
+ * &lt;fossil&gt;
+ *   &lt;modelFile&gt;my-model.txt&lt;/modelFile&gt;
+ *   &lt;importer&gt;lightgbm&lt;/importer&gt;
+ *   &lt;modelType&gt;regressor&lt;/modelType&gt;
+ *   &lt;targetPackageName&gt;com.example.models&lt;/targetPackageName&gt;
+ * &lt;/fossil&gt;
+ * </pre>
+ */
 @Data
 public class FossilConfig {
+
+	/**
+	 * Directory containing the model file. If omitted, defaults to {@code src/main/models} relative
+	 * to the project base directory.
+	 */
 	private String modelDirectory;
+
+	/**
+	 * Filename of the model to compile, resolved relative to {@link #modelDirectory}. Required.
+	 */
 	private String modelFile;
-	private String importer;
-	private String modelType;
+
+	/**
+	 * Which importer parses the model file. See {@link Importer} for valid values.
+	 *
+	 * <p>Required. Eclipse and IntelliJ will offer autocomplete once this enum type is published.
+	 */
+	private Importer importer;
+
+	/**
+	 * Whether this model is a classifier or a regressor. See {@link ModelType} for valid values.
+	 *
+	 * <p>Required. Eclipse and IntelliJ will offer autocomplete once this enum type is published.
+	 */
+	private ModelType modelType;
+
+	/**
+	 * Package name of the generated fossil class. Required.
+	 */
 	private String targetPackageName;
+
+	/**
+	 * Base name of the generated fossil class; the suffix {@code Fossil} is appended automatically.
+	 * If omitted, the class name is derived from {@link #modelFile} by stripping the extension and
+	 * camel-casing the remainder.
+	 */
 	private String targetClassName;
+
+	/**
+	 * Optional human-readable model name baked into the generated fossil's metadata. Retrievable at
+	 * runtime via {@code Fossil.getModelName()}.
+	 */
 	private String modelName;
+
+	/**
+	 * Optional model version string baked into the generated fossil's metadata. Retrievable at
+	 * runtime via {@code Fossil.getModelVersion()}.
+	 */
 	private String modelVersion;
+
+	/**
+	 * Comma-separated override for the feature-name list baked into the generated fossil. Useful when
+	 * the source model does not embed feature names or embeds incorrect ones. Retrievable at runtime
+	 * via {@code Fossil.getFeatureNames()}.
+	 */
 	private String featureNames;
+
+	/**
+	 * If true, discards any feature-name list parsed from the source model. Has no effect when
+	 * {@link #featureNames} is set (the override takes precedence regardless).
+	 */
 	private boolean ignoreFeatureNamesFromModel;
 
 	public String[] resolveFeatureNames() {

--- a/petrify-maven-plugin/src/main/java/com/github/exabrial/petrify/maven/FossilizeMojo.java
+++ b/petrify-maven-plugin/src/main/java/com/github/exabrial/petrify/maven/FossilizeMojo.java
@@ -29,15 +29,19 @@ import com.github.exabrial.petrify.imprt.onnx.OnnxArborist;
 import com.github.exabrial.petrify.imprt.onnx.OnnxVintner;
 import com.github.exabrial.petrify.imprt.scikit.ScikitVintner;
 
+/**
+ * Compiles machine-learning models into JVM bytecode at build time.
+ *
+ * <p>For each {@code <fossil>} entry in the plugin configuration, reads the source model file,
+ * parses it with the selected {@link Importer}, compiles it into a fossil class implementing the
+ * appropriate {@code Fossil} interface for its {@link ModelType}, and writes the resulting
+ * {@code .class} file into {@code ${project.build.outputDirectory}}.
+ *
+ * <p>Binds to {@link LifecyclePhase#GENERATE_RESOURCES} by default so generated classes are
+ * available on the compile classpath.
+ */
 @Mojo(name = "fossilize", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
 public class FossilizeMojo extends AbstractMojo {
-	private static final String IMPORTER_LIGHTGBM = "lightgbm";
-	private static final String IMPORTER_ONNX = "onnx";
-	private static final String IMPORTER_SCIKIT = "scikit";
-
-	private static final String MODEL_TYPE_CLASSIFIER = "classifier";
-	private static final String MODEL_TYPE_REGRESSOR = "regressor";
-
 	private static final String PETRIFY_CLASSES_DIR = "petrify-classes";
 	private static final String PETRIFY_CLASSPATH_ENTRY = "<classpathentry exported=\"true\" kind=\"lib\" path=\"target/"
 			+ PETRIFY_CLASSES_DIR + "\"/>";
@@ -51,15 +55,36 @@ public class FossilizeMojo extends AbstractMojo {
 	@Parameter(defaultValue = "${project}", readonly = true, required = true)
 	private MavenProject project;
 
+	/**
+	 * One or more models to compile. Each entry describes a single source model file and how to
+	 * translate it into a fossil class. Required; the goal fails if this list is empty.
+	 *
+	 * @see FossilConfig
+	 */
 	@Parameter(required = true)
 	private FossilConfig[] fossils;
 
+	/**
+	 * Destination directory for generated fossil class files. Defaults to the project's standard
+	 * build output directory ({@code target/classes}).
+	 */
 	@Parameter(defaultValue = "${project.build.outputDirectory}")
 	private String outputDirectory;
 
+	/**
+	 * When {@code true}, the goal becomes a no-op. Useful for disabling fossil compilation in a
+	 * specific profile or build. Controlled by the {@code petrify.skip} system property.
+	 */
 	@Parameter(property = "petrify.skip", defaultValue = "false")
 	private boolean skip;
 
+	/**
+	 * When {@code true}, disables the Eclipse-specific integration that writes an extra copy of each
+	 * compiled class into a sibling {@code petrify-classes} directory and registers it in
+	 * {@code .classpath}. The integration activates automatically when Eclipse m2e is detected as the
+	 * build context; set this flag to override that detection. Controlled by the
+	 * {@code petrify.disableEclipseIntegration} system property.
+	 */
 	@Parameter(property = "petrify.disableEclipseIntegration", defaultValue = "false")
 	private boolean disableEclipseIntegration;
 
@@ -121,9 +146,9 @@ public class FossilizeMojo extends AbstractMojo {
 			throws MojoFailureException {
 		if (fossil.getModelFile() == null || fossil.getModelFile().isEmpty()) {
 			throw new MojoFailureException("modelFile is required");
-		} else if (fossil.getImporter() == null || fossil.getImporter().isEmpty()) {
+		} else if (fossil.getImporter() == null) {
 			throw new MojoFailureException("importer is required for modelFile:" + fossil.getModelFile());
-		} else if (fossil.getModelType() == null || fossil.getModelType().isEmpty()) {
+		} else if (fossil.getModelType() == null) {
 			throw new MojoFailureException("modelType is required for modelFile:" + fossil.getModelFile());
 		} else if (fossil.getTargetPackageName() == null || fossil.getTargetPackageName().isEmpty()) {
 			throw new MojoFailureException("targetPackageName is required for modelFile:" + fossil.getModelFile());
@@ -131,19 +156,6 @@ public class FossilizeMojo extends AbstractMojo {
 			throw new MojoFailureException("modelFile not found:" + modelPath);
 		} else if (resolvedClassName == null || resolvedClassName.isEmpty()) {
 			throw new MojoFailureException("className could not be resolved for modelFile:" + fossil.getModelFile());
-		} else {
-			switch (fossil.getImporter()) {
-				case IMPORTER_LIGHTGBM, IMPORTER_ONNX, IMPORTER_SCIKIT -> {
-				}
-				default -> throw new MojoFailureException(
-						"unknown importer:" + fossil.getImporter() + " for modelFile:" + fossil.getModelFile());
-			}
-			switch (fossil.getModelType()) {
-				case MODEL_TYPE_CLASSIFIER, MODEL_TYPE_REGRESSOR -> {
-				}
-				default -> throw new MojoFailureException(
-						"unknown modelType:" + fossil.getModelType() + " for modelFile:" + fossil.getModelFile());
-			}
 		}
 	}
 
@@ -152,33 +164,32 @@ public class FossilizeMojo extends AbstractMojo {
 		final BuildTimePetrify petrify = new BuildTimePetrify();
 		petrify.setTarget(packageName, resolvedClassName);
 
-		final String importer = fossil.getImporter();
-		final String modelType = fossil.getModelType();
+		final Importer importer = fossil.getImporter();
+		final ModelType modelType = fossil.getModelType();
 		switch (importer) {
-			case IMPORTER_LIGHTGBM -> {
+			case lightgbm -> {
 				compileLightgbm(petrify, modelBytes, modelType, fossil);
 			}
-			case IMPORTER_ONNX -> {
+			case onnx -> {
 				compileOnnx(petrify, modelBytes, modelType, fossil);
 			}
-			case IMPORTER_SCIKIT -> {
+			case scikit -> {
 				compileScikit(petrify, modelBytes, modelType, fossil);
 			}
-			default -> throw new MojoExecutionException("compile() unknown importer:" + importer);
 		}
 		return petrify.getFossilBytes();
 	}
 
-	protected void compileLightgbm(final BuildTimePetrify petrify, final byte[] modelBytes, final String modelType,
+	protected void compileLightgbm(final BuildTimePetrify petrify, final byte[] modelBytes, final ModelType modelType,
 			final FossilConfig fossilConfig) {
 		final LightGbmArborist arborist = new LightGbmArborist();
 		switch (modelType) {
-			case MODEL_TYPE_CLASSIFIER -> {
+			case classifier -> {
 				final ClassifierGrove grove = arborist.toGrove(modelBytes);
 				applyConfigMetadata(grove, fossilConfig);
 				petrify.fossilize(null, grove);
 			}
-			case MODEL_TYPE_REGRESSOR -> {
+			case regressor -> {
 				final RegressorGrove grove = arborist.toGrove(modelBytes);
 				applyConfigMetadata(grove, fossilConfig);
 				petrify.fossilize(null, grove);
@@ -186,13 +197,13 @@ public class FossilizeMojo extends AbstractMojo {
 		}
 	}
 
-	protected void compileOnnx(final BuildTimePetrify petrify, final byte[] modelBytes, final String modelType,
+	protected void compileOnnx(final BuildTimePetrify petrify, final byte[] modelBytes, final ModelType modelType,
 			final FossilConfig fossilConfig) {
 		switch (modelType) {
-			case MODEL_TYPE_CLASSIFIER -> {
+			case classifier -> {
 				compileOnnxClassifier(petrify, modelBytes, fossilConfig);
 			}
-			case MODEL_TYPE_REGRESSOR -> {
+			case regressor -> {
 				compileOnnxRegressor(petrify, modelBytes, fossilConfig);
 			}
 		}
@@ -238,16 +249,16 @@ public class FossilizeMojo extends AbstractMojo {
 		}
 	}
 
-	protected void compileScikit(final BuildTimePetrify petrify, final byte[] modelBytes, final String modelType,
+	protected void compileScikit(final BuildTimePetrify petrify, final byte[] modelBytes, final ModelType modelType,
 			final FossilConfig fossilConfig) {
 		final ScikitVintner vintner = new ScikitVintner();
 		switch (modelType) {
-			case MODEL_TYPE_CLASSIFIER -> {
+			case classifier -> {
 				final ClassifierVine vine = vintner.toVine(modelBytes);
 				applyConfigMetadata(vine, fossilConfig);
 				petrify.fossilize(null, vine);
 			}
-			case MODEL_TYPE_REGRESSOR -> {
+			case regressor -> {
 				final RegressorVine vine = vintner.toVine(modelBytes);
 				applyConfigMetadata(vine, fossilConfig);
 				petrify.fossilize(null, vine);

--- a/petrify-maven-plugin/src/main/java/com/github/exabrial/petrify/maven/Importer.java
+++ b/petrify-maven-plugin/src/main/java/com/github/exabrial/petrify/maven/Importer.java
@@ -1,0 +1,33 @@
+package com.github.exabrial.petrify.maven;
+
+/**
+ * Identifies which arborist or vintner is used to parse a model file.
+ *
+ * <p>Enum constants are lowercase by convention to match the plugin's existing XML configuration
+ * syntax; this is unusual for Java but preserves backward compatibility with prior releases where
+ * the field was a plain {@code String}.
+ */
+public enum Importer {
+	/**
+	 * LightGBM native text-format model (the {@code .txt} produced by {@code saveModelToString}).
+	 * Supports both classifier and regressor model types. Handled by
+	 * {@code com.github.exabrial.petrify.imprt.lightgbm.LightGbmArborist}.
+	 */
+	lightgbm,
+
+	/**
+	 * ONNX model file (typically {@code .onnx}). Attempts tree-ensemble (arborist) parsing first and
+	 * falls back to linear (vintner) parsing if tree parsing fails. Supports both classifier and
+	 * regressor model types.
+	 */
+	onnx,
+
+	/**
+	 * scikit-learn linear model serialized to petrify's JSON format (matching the
+	 * {@code ScikitLinearModel} schema: {@code type}, {@code coefficients}, {@code intercepts},
+	 * {@code classLabels}, {@code postTransform}, and optional metadata fields). Supports both
+	 * classifier and regressor model types; tree-based scikit models should be exported to ONNX
+	 * instead. Handled by {@code com.github.exabrial.petrify.imprt.scikit.ScikitVintner}.
+	 */
+	scikit
+}

--- a/petrify-maven-plugin/src/main/java/com/github/exabrial/petrify/maven/ModelType.java
+++ b/petrify-maven-plugin/src/main/java/com/github/exabrial/petrify/maven/ModelType.java
@@ -1,0 +1,25 @@
+package com.github.exabrial.petrify.maven;
+
+/**
+ * Identifies whether a model is a classifier or regressor, which determines how the model's output
+ * is interpreted and which {@code Fossil} interface the generated class implements.
+ *
+ * <p>Enum constants are lowercase by convention to match the plugin's existing XML configuration
+ * syntax; this is unusual for Java but preserves backward compatibility with prior releases where
+ * the field was a plain {@code String}.
+ */
+public enum ModelType {
+	/**
+	 * A classification model. The generated fossil implements
+	 * {@code com.github.exabrial.petrify.model.ClassifierFossil} and its {@code predict} method
+	 * returns the predicted class label.
+	 */
+	classifier,
+
+	/**
+	 * A regression model. The generated fossil implements
+	 * {@code com.github.exabrial.petrify.model.RegressionFossil} and its {@code predict} method
+	 * returns a continuous numeric score.
+	 */
+	regressor
+}


### PR DESCRIPTION
Close #19 - use enums and javadoc on maven configuration objects so IDEs can discover options