### PR TITLE
Close #22 - large models busting the constant pool

### DIFF
--- a/petrify-maven-plugin/src/main/java/com/github/exabrial/petrify/maven/BuildTimePetrify.java
+++ b/petrify-maven-plugin/src/main/java/com/github/exabrial/petrify/maven/BuildTimePetrify.java
@@ -2,20 +2,29 @@ package com.github.exabrial.petrify.maven;
 
 import java.lang.constant.ClassDesc;
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
+import com.github.exabrial.petrify.CompiledModel;
 import com.github.exabrial.petrify.Petrify;
 import com.github.exabrial.petrify.model.Fossil;
 
 public class BuildTimePetrify extends Petrify {
 	private ClassDesc classDesc;
-	private byte[] fossilBytes;
+	private CompiledModel fossilClass;
+	private final List<CompiledModel> innerClasses = new ArrayList<>();
 
 	public void setTarget(final String packageName, final String className) {
 		classDesc = ClassDesc.of(packageName, className);
 	}
 
-	public byte[] getFossilBytes() {
-		return fossilBytes;
+	public CompiledModel getFossilClass() {
+		return fossilClass;
+	}
+
+	public List<CompiledModel> getInnerClasses() {
+		return Collections.unmodifiableList(innerClasses);
 	}
 
 	@Override
@@ -24,9 +33,14 @@ public class BuildTimePetrify extends Petrify {
 	}
 
 	@Override
-	protected <T extends Fossil> T defineFossil(final MethodHandles.Lookup lookup, final byte[] fossilBytes,
+	protected <T extends Fossil> T defineFossil(final MethodHandles.Lookup lookup, final CompiledModel compiledClass,
 			final Class<T> fossilType) {
-		this.fossilBytes = fossilBytes;
+		this.fossilClass = compiledClass;
 		return null;
+	}
+
+	@Override
+	protected void defineInnerClass(final MethodHandles.Lookup lookup, final CompiledModel compiledClass) {
+		this.innerClasses.add(compiledClass);
 	}
 }

--- a/petrify-maven-plugin/src/main/java/com/github/exabrial/petrify/maven/FossilizeMojo.java
+++ b/petrify-maven-plugin/src/main/java/com/github/exabrial/petrify/maven/FossilizeMojo.java
@@ -17,6 +17,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.sonatype.plexus.build.incremental.BuildContext;
 
+import com.github.exabrial.petrify.CompiledModel;
 import com.github.exabrial.petrify.compiler.model.ClassifierGrove;
 import com.github.exabrial.petrify.compiler.model.ClassifierVine;
 import com.github.exabrial.petrify.compiler.model.Grove;
@@ -32,13 +33,13 @@ import com.github.exabrial.petrify.imprt.scikit.ScikitVintner;
 /**
  * Compiles machine-learning models into JVM bytecode at build time.
  *
- * <p>For each {@code <fossil>} entry in the plugin configuration, reads the source model file,
- * parses it with the selected {@link Importer}, compiles it into a fossil class implementing the
- * appropriate {@code Fossil} interface for its {@link ModelType}, and writes the resulting
- * {@code .class} file into {@code ${project.build.outputDirectory}}.
+ * <p>
+ * For each {@code <fossil>} entry in the plugin configuration, reads the source model file, parses it with the selected
+ * {@link Importer}, compiles it into a fossil class implementing the appropriate {@code Fossil} interface for its {@link ModelType},
+ * and writes the resulting {@code .class} file into {@code ${project.build.outputDirectory}}.
  *
- * <p>Binds to {@link LifecyclePhase#GENERATE_RESOURCES} by default so generated classes are
- * available on the compile classpath.
+ * <p>
+ * Binds to {@link LifecyclePhase#GENERATE_RESOURCES} by default so generated classes are available on the compile classpath.
  */
 @Mojo(name = "fossilize", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
 public class FossilizeMojo extends AbstractMojo {
@@ -56,8 +57,8 @@ public class FossilizeMojo extends AbstractMojo {
 	private MavenProject project;
 
 	/**
-	 * One or more models to compile. Each entry describes a single source model file and how to
-	 * translate it into a fossil class. Required; the goal fails if this list is empty.
+	 * One or more models to compile. Each entry describes a single source model file and how to translate it into a fossil class.
+	 * Required; the goal fails if this list is empty.
 	 *
 	 * @see FossilConfig
 	 */
@@ -65,24 +66,23 @@ public class FossilizeMojo extends AbstractMojo {
 	private FossilConfig[] fossils;
 
 	/**
-	 * Destination directory for generated fossil class files. Defaults to the project's standard
-	 * build output directory ({@code target/classes}).
+	 * Destination directory for generated fossil class files. Defaults to the project's standard build output directory
+	 * ({@code target/classes}).
 	 */
 	@Parameter(defaultValue = "${project.build.outputDirectory}")
 	private String outputDirectory;
 
 	/**
-	 * When {@code true}, the goal becomes a no-op. Useful for disabling fossil compilation in a
-	 * specific profile or build. Controlled by the {@code petrify.skip} system property.
+	 * When {@code true}, the goal becomes a no-op. Useful for disabling fossil compilation in a specific profile or build. Controlled by
+	 * the {@code petrify.skip} system property.
 	 */
 	@Parameter(property = "petrify.skip", defaultValue = "false")
 	private boolean skip;
 
 	/**
-	 * When {@code true}, disables the Eclipse-specific integration that writes an extra copy of each
-	 * compiled class into a sibling {@code petrify-classes} directory and registers it in
-	 * {@code .classpath}. The integration activates automatically when Eclipse m2e is detected as the
-	 * build context; set this flag to override that detection. Controlled by the
+	 * When {@code true}, disables the Eclipse-specific integration that writes an extra copy of each compiled class into a sibling
+	 * {@code petrify-classes} directory and registers it in {@code .classpath}. The integration activates automatically when Eclipse m2e
+	 * is detected as the build context; set this flag to override that detection. Controlled by the
 	 * {@code petrify.disableEclipseIntegration} system property.
 	 */
 	@Parameter(property = "petrify.disableEclipseIntegration", defaultValue = "false")
@@ -177,7 +177,17 @@ public class FossilizeMojo extends AbstractMojo {
 				compileScikit(petrify, modelBytes, modelType, fossil);
 			}
 		}
-		return petrify.getFossilBytes();
+
+		for (final CompiledModel innerClass : petrify.getInnerClasses()) {
+			final Path innerOutputPath = resolveOutputPath(outputDirectory, packageName, innerClass.className());
+			writeClassFile(innerOutputPath, innerClass.classBytes());
+			if (isEclipseIntegrationEnabled()) {
+				final Path innerEclipsePath = resolveEclipseOutputPath(packageName, innerClass.className());
+				writeClassFile(innerEclipsePath, innerClass.classBytes());
+			}
+		}
+
+		return petrify.getFossilClass().classBytes();
 	}
 
 	protected void compileLightgbm(final BuildTimePetrify petrify, final byte[] modelBytes, final ModelType modelType,
@@ -209,8 +219,7 @@ public class FossilizeMojo extends AbstractMojo {
 		}
 	}
 
-	protected void compileOnnxClassifier(final BuildTimePetrify petrify, final byte[] modelBytes,
-			final FossilConfig fossilConfig) {
+	protected void compileOnnxClassifier(final BuildTimePetrify petrify, final byte[] modelBytes, final FossilConfig fossilConfig) {
 		try {
 			final OnnxArborist arborist = new OnnxArborist();
 			final ClassifierGrove grove = arborist.toGrove(modelBytes);
@@ -229,8 +238,7 @@ public class FossilizeMojo extends AbstractMojo {
 		}
 	}
 
-	protected void compileOnnxRegressor(final BuildTimePetrify petrify, final byte[] modelBytes,
-			final FossilConfig fossilConfig) {
+	protected void compileOnnxRegressor(final BuildTimePetrify petrify, final byte[] modelBytes, final FossilConfig fossilConfig) {
 		try {
 			final OnnxArborist arborist = new OnnxArborist();
 			final RegressorGrove grove = arborist.toGrove(modelBytes);

--- a/petrify-testing/src/test/java/com/github/exabrial/petrify/testing/lightgbm/BigLightgbmRegressorHousingTest.java
+++ b/petrify-testing/src/test/java/com/github/exabrial/petrify/testing/lightgbm/BigLightgbmRegressorHousingTest.java
@@ -1,0 +1,131 @@
+package com.github.exabrial.petrify.testing.lightgbm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.invoke.MethodHandles;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.exabrial.petrify.Petrify;
+import com.github.exabrial.petrify.compiler.model.RegressorGrove;
+import com.github.exabrial.petrify.imprt.Arborist;
+import com.github.exabrial.petrify.imprt.lightgbm.LightGbmArborist;
+import com.github.exabrial.petrify.model.RegressionFossil;
+
+/**
+ * Uses a LightGBM native text model with 5000 estimators to exercise the constant pool spill path. Trained on California housing data,
+ * max_depth=6, num_leaves=31, learning_rate=0.01, objective=regression, 8 input features (MedInc, HouseAge, AveRooms, AveBedrms,
+ * Population, AveOccup, Latitude, Longitude). F64 precision mode. At ~60 CP entries per tree, 5000 trees produces ~300,000 CP entries
+ * requiring multiple inner classes to hold all tree methods.
+ */
+@TestInstance(Lifecycle.PER_CLASS)
+class BigLightgbmRegressorHousingTest {
+	private static final String MODEL = "/test-models/bigLightgbmRegressorHousing.txt";
+	private final Logger log = LoggerFactory.getLogger(getClass());
+	private RegressionFossil fossil;
+
+	@BeforeAll
+	void beforeAll() {
+		final Arborist arborist = new LightGbmArborist();
+		final RegressorGrove grove = arborist.toGrove(MODEL);
+
+		final Petrify petrify = new Petrify();
+		fossil = petrify.fossilize(MethodHandles.lookup(), grove);
+	}
+
+	@BeforeEach
+	void beforeEach(final TestInfo testInfo) {
+		log.info("beforeEach() starting test:{}", testInfo.getDisplayName());
+	}
+
+	@Test
+	void testPredict_0() {
+		final double actual = fossil
+				.predict(new double[] { 2.8208, 33.0, 4.051020408163265, 1.1581632653061225, 739.0, 1.885204081632653, 34.17, -118.38 });
+		assertEquals(2.9340969896705684d, actual);
+	}
+
+	@Test
+	void testPredict_1() {
+		final double actual = fossil
+				.predict(new double[] { 4.3611, 11.0, 5.419753086419753, 0.9629629629629629, 655.0, 2.6954732510288064, 35.06, -120.52 });
+		assertEquals(1.7202823961944005d, actual);
+	}
+
+	@Test
+	void testPredict_2() {
+		final double actual = fossil
+				.predict(new double[] { 4.3482, 9.0, 5.7924528301886795, 1.1037735849056605, 409.0, 1.929245283018868, 35.36, -119.06 });
+		assertEquals(1.000416354665132d, actual);
+	}
+
+	@Test
+	void testPredict_3() {
+		final double actual = fossil
+				.predict(new double[] { 4.5787, 20.0, 6.117370892018779, 0.9953051643192489, 1361.0, 3.1948356807511735, 36.85, -121.65 });
+		assertEquals(2.4047736715362236d, actual);
+	}
+
+	@Test
+	void testPredict_4() {
+		final double actual = fossil
+				.predict(new double[] { 2.5, 19.0, 6.153153153153153, 1.2522522522522523, 302.0, 2.720720720720721, 40.28, -120.96 });
+		assertEquals(0.8633735877005969d, actual);
+	}
+
+	@Test
+	void testPredict_5() {
+		final double actual = fossil
+				.predict(new double[] { 5.6413, 35.0, 5.361702127659575, 0.9281914893617021, 1023.0, 2.720744680851064, 37.44, -122.11 });
+		assertEquals(3.3514828428518d, actual);
+	}
+
+	@Test
+	void testPredict_6() {
+		final double actual = fossil
+				.predict(new double[] { 6.0531, 25.0, 5.833333333333333, 1.0021097046413503, 1666.0, 3.5147679324894514, 33.8, -117.81 });
+		assertEquals(2.204016210365464d, actual);
+	}
+
+	@Test
+	void testPredict_7() {
+		final double actual = fossil
+				.predict(new double[] { 3.6944, 29.0, 4.048744460856721, 0.9852289512555391, 2449.0, 3.617429837518464, 34.08, -118.02 });
+		assertEquals(1.9188902138665156d, actual);
+	}
+
+	@Test
+	void testPredict_8() {
+		final double actual = fossil
+				.predict(new double[] { 12.3292, 29.0, 7.916666666666667, 1.0555555555555556, 244.0, 3.388888888888889, 37.38, -121.81 });
+		assertEquals(4.5547077763071355d, actual);
+	}
+
+	@Test
+	void testPredict_9() {
+		final double actual = fossil
+				.predict(new double[] { 2.2031, 36.0, 4.170068027210885, 1.129251700680272, 425.0, 2.891156462585034, 38.57, -121.51 });
+		assertEquals(0.7700434204952608d, actual);
+	}
+
+	@Test
+	void testPredict_10() {
+		final double actual = fossil
+				.predict(new double[] { 4.0789, 35.0, 5.640198511166253, 1.0173697270471465, 1431.0, 3.5508684863523574, 34.2, -118.56 });
+		assertEquals(2.005378264685653d, actual);
+	}
+
+	@Test
+	void testPredict_11() {
+		final double actual = fossil
+				.predict(new double[] { 1.4012, 52.0, 3.105714285714286, 1.06, 3337.0, 9.534285714285714, 37.87, -122.26 });
+		assertEquals(3.3501070462720026d, actual);
+	}
+}

--- a/petrify/src/main/java/com/github/exabrial/petrify/CompiledModel.java
+++ b/petrify/src/main/java/com/github/exabrial/petrify/CompiledModel.java
@@ -1,0 +1,4 @@
+package com.github.exabrial.petrify;
+
+public record CompiledModel(String className, byte[] classBytes) {
+}

--- a/petrify/src/main/java/com/github/exabrial/petrify/Petrify.java
+++ b/petrify/src/main/java/com/github/exabrial/petrify/Petrify.java
@@ -60,6 +60,8 @@ public class Petrify {
 	protected static final int TREE_SLOT_SCORES = 1;
 	protected static final String TREE_METHOD_PREFIX = "tree_";
 
+	protected static final String INNER_CLASS_PREFIX = "$Trees";
+
 	protected static final int CP_ENTRIES_PER_CROSS_CLASS_INVOCATION = 5;
 	public static final int DEFAULT_CONSTANT_POOL_SOFT_MAX = 55000;
 
@@ -86,6 +88,7 @@ public class Petrify {
 			final ClassifierStratum stratum = new ClassifierStratum(grove);
 
 			final ClassDesc thisClass = nextClassDesc(lookup);
+			final List<byte[]> innerClassBytes = new ArrayList<>();
 			final byte[] fossilBytes = ClassFile.of().build(thisClass, (final ClassBuilder classBuilder) -> {
 				setJdk(classBuilder);
 				setClassFlags(classBuilder);
@@ -94,10 +97,13 @@ public class Petrify {
 				createSerialVersionUid(classBuilder);
 				createDefaultConstructor(classBuilder);
 				emitMetadataMethods(classBuilder, grove.metadata);
-				final ClassDesc[] treeOwners = createMethodPerEnsemble(classBuilder, stratum, thisClass);
+				final ClassDesc[] treeOwners = createMethodPerEnsemble(classBuilder, stratum, thisClass, innerClassBytes);
 				implementClassifierPredictMethod(classBuilder, stratum, treeOwners);
 			});
 
+			for (final byte[] innerBytes : innerClassBytes) {
+				lookup.defineClass(innerBytes);
+			}
 			final ClassifierFossil fossil = defineFossil(lookup, fossilBytes, ClassifierFossil.class);
 			return fossil;
 		} catch (final Exception e) {
@@ -113,6 +119,7 @@ public class Petrify {
 			final RegressorStratum stratum = new RegressorStratum(grove);
 
 			final ClassDesc thisClass = nextClassDesc(lookup);
+			final List<byte[]> innerClassBytes = new ArrayList<>();
 			final byte[] fossilBytes = ClassFile.of().build(thisClass, (final ClassBuilder classBuilder) -> {
 				setJdk(classBuilder);
 				setClassFlags(classBuilder);
@@ -121,10 +128,13 @@ public class Petrify {
 				createSerialVersionUid(classBuilder);
 				createDefaultConstructor(classBuilder);
 				emitMetadataMethods(classBuilder, grove.metadata);
-				final ClassDesc[] treeOwners = createMethodPerEnsemble(classBuilder, stratum, thisClass);
+				final ClassDesc[] treeOwners = createMethodPerEnsemble(classBuilder, stratum, thisClass, innerClassBytes);
 				implementRegressorPredictMethod(classBuilder, stratum, treeOwners);
 			});
 
+			for (final byte[] innerBytes : innerClassBytes) {
+				lookup.defineClass(innerBytes);
+			}
 			final RegressionFossil fossil = defineFossil(lookup, fossilBytes, RegressionFossil.class);
 			return fossil;
 		} catch (final Exception e) {
@@ -449,30 +459,46 @@ public class Petrify {
 		}
 	}
 
-	protected ClassDesc[] createMethodPerEnsemble(final ClassBuilder classBuilder, final Stratum stratum, final ClassDesc thisClass) {
+	protected ClassDesc[] createMethodPerEnsemble(final ClassBuilder classBuilder, final Stratum stratum, final ClassDesc thisClass,
+			final List<byte[]> innerClassBytes) {
 		final ByteCodeAdapter adapter = getByteCodeAdapter(stratum.grove.precisionMode);
 		final MethodTypeDesc treeMethodDesc = MethodTypeDesc.of(ConstantDescs.CD_void, adapter.arrayDesc(), adapter.arrayDesc());
-		final ClassDesc[] treeOwners = new ClassDesc[stratum.treeRootIds.length];
-		int treeIdx = 0;
+		final int[] treeRootIds = stratum.treeRootIds;
+		final ClassDesc[] treeOwners = new ClassDesc[treeRootIds.length];
+		final int[] treeIdxHolder = { 0 };
 		// Fossil phase: pack trees onto the fossil class, reserving CP headroom for cross-class invocations
-		while (treeIdx < stratum.treeRootIds.length) {
-			final int remainingTrees = stratum.treeRootIds.length - treeIdx;
-			final int projectedCpUsage = classBuilder.constantPool().size() + remainingTrees * CP_ENTRIES_PER_CROSS_CLASS_INVOCATION;
-			if (projectedCpUsage >= constantPoolSoftMax) {
-				log.debug("createMethodPerEnsemble() fossil spill at tree index:{}, constantPoolSize:{} remainingTrees:{}", treeIdx,
-						classBuilder.constantPool().size(), remainingTrees);
-				break;
-			} else {
-				final int treeId = stratum.treeRootIds[treeIdx];
-				final int rootArrayIdx = stratum.nodeIndex.get(PetrifyConstants.packLong(treeId, 0));
-				emitTreeMethod(classBuilder, treeMethodDesc, stratum, treeId, rootArrayIdx);
-				treeOwners[treeIdx] = thisClass;
-				treeIdx++;
-			}
+		while (treeIdxHolder[0] < treeRootIds.length && classBuilder.constantPool().size()
+				+ (treeRootIds.length - treeIdxHolder[0]) * CP_ENTRIES_PER_CROSS_CLASS_INVOCATION < constantPoolSoftMax) {
+			final int treeId = treeRootIds[treeIdxHolder[0]];
+			final int rootArrayIdx = stratum.nodeIndex.get(PetrifyConstants.packLong(treeId, 0));
+			emitTreeMethod(classBuilder, treeMethodDesc, stratum, treeId, rootArrayIdx);
+			treeOwners[treeIdxHolder[0]] = thisClass;
+			treeIdxHolder[0]++;
 		}
-		if (treeIdx < stratum.treeRootIds.length) {
-			// TODO: inner class phase (step 4) — remaining trees at index i..treeRootIds.length
+		if (treeIdxHolder[0] < treeRootIds.length) {
+			log.debug("createMethodPerEnsemble() fossil spill at treeIdx:{} constantPoolSize:{} remainingTrees:{}", treeIdxHolder[0],
+					classBuilder.constantPool().size(), treeRootIds.length - treeIdxHolder[0]);
 		}
+		// Inner class phase: spill remaining trees into static inner classes
+		int innerClassCounter = 0;
+		while (treeIdxHolder[0] < treeRootIds.length) {
+			final ClassDesc innerClassDesc = ClassDesc.of(thisClass.packageName(),
+					thisClass.displayName() + INNER_CLASS_PREFIX + innerClassCounter);
+			final byte[] innerBytes = ClassFile.of().build(innerClassDesc, (final ClassBuilder innerBuilder) -> {
+				setJdk(innerBuilder);
+				innerBuilder.withFlags(ClassFile.ACC_FINAL | ClassFile.ACC_SUPER);
+				while (treeIdxHolder[0] < treeRootIds.length && innerBuilder.constantPool().size() < constantPoolSoftMax) {
+					final int treeId = treeRootIds[treeIdxHolder[0]];
+					final int rootArrayIdx = stratum.nodeIndex.get(PetrifyConstants.packLong(treeId, 0));
+					emitTreeMethod(innerBuilder, treeMethodDesc, stratum, treeId, rootArrayIdx);
+					treeOwners[treeIdxHolder[0]] = innerClassDesc;
+					treeIdxHolder[0]++;
+				}
+			});
+			innerClassBytes.add(innerBytes);
+			innerClassCounter++;
+		}
+		log.info("createMethodPerEnsemble() trees:{} innerClasses:{}", treeRootIds.length, innerClassCounter);
 		return treeOwners;
 	}
 
@@ -488,11 +514,10 @@ public class Petrify {
 	protected void emitTreeMethod(final ClassBuilder classBuilder, final MethodTypeDesc treeMethodDesc, final Stratum stratum,
 			final int treeId, final int rootArrayIdx) {
 		// slot layout: features=0, scores=1
-		classBuilder.withMethodBody(TREE_METHOD_PREFIX + treeId, treeMethodDesc, ClassFile.ACC_PRIVATE | ClassFile.ACC_STATIC,
-				(final CodeBuilder codeBuilder) -> {
-					emitTree(codeBuilder, stratum, treeId, rootArrayIdx);
-					codeBuilder.return_();
-				});
+		classBuilder.withMethodBody(TREE_METHOD_PREFIX + treeId, treeMethodDesc, ClassFile.ACC_STATIC, (final CodeBuilder codeBuilder) -> {
+			emitTree(codeBuilder, stratum, treeId, rootArrayIdx);
+			codeBuilder.return_();
+		});
 	}
 
 	protected void emitTree(final CodeBuilder codeBuilder, final Stratum stratum, final int treeId, final int arrayIdx) {

--- a/petrify/src/main/java/com/github/exabrial/petrify/Petrify.java
+++ b/petrify/src/main/java/com/github/exabrial/petrify/Petrify.java
@@ -88,7 +88,7 @@ public class Petrify {
 			final ClassifierStratum stratum = new ClassifierStratum(grove);
 
 			final ClassDesc thisClass = nextClassDesc(lookup);
-			final List<byte[]> innerClassBytes = new ArrayList<>();
+			final List<CompiledModel> innerClasses = new ArrayList<>();
 			final byte[] fossilBytes = ClassFile.of().build(thisClass, (final ClassBuilder classBuilder) -> {
 				setJdk(classBuilder);
 				setClassFlags(classBuilder);
@@ -97,14 +97,15 @@ public class Petrify {
 				createSerialVersionUid(classBuilder);
 				createDefaultConstructor(classBuilder);
 				emitMetadataMethods(classBuilder, grove.metadata);
-				final ClassDesc[] treeOwners = createMethodPerEnsemble(classBuilder, stratum, thisClass, innerClassBytes);
+				final ClassDesc[] treeOwners = createMethodPerEnsemble(classBuilder, stratum, thisClass, innerClasses);
 				implementClassifierPredictMethod(classBuilder, stratum, treeOwners);
 			});
 
-			for (final byte[] innerBytes : innerClassBytes) {
-				lookup.defineClass(innerBytes);
+			for (final CompiledModel innerClass : innerClasses) {
+				defineInnerClass(lookup, innerClass);
 			}
-			final ClassifierFossil fossil = defineFossil(lookup, fossilBytes, ClassifierFossil.class);
+			final CompiledModel fossilClass = new CompiledModel(thisClass.displayName(), fossilBytes);
+			final ClassifierFossil fossil = defineFossil(lookup, fossilClass, ClassifierFossil.class);
 			return fossil;
 		} catch (final Exception e) {
 			throw new UnexpectedCometImpact(e);
@@ -119,7 +120,7 @@ public class Petrify {
 			final RegressorStratum stratum = new RegressorStratum(grove);
 
 			final ClassDesc thisClass = nextClassDesc(lookup);
-			final List<byte[]> innerClassBytes = new ArrayList<>();
+			final List<CompiledModel> innerClasses = new ArrayList<>();
 			final byte[] fossilBytes = ClassFile.of().build(thisClass, (final ClassBuilder classBuilder) -> {
 				setJdk(classBuilder);
 				setClassFlags(classBuilder);
@@ -128,14 +129,15 @@ public class Petrify {
 				createSerialVersionUid(classBuilder);
 				createDefaultConstructor(classBuilder);
 				emitMetadataMethods(classBuilder, grove.metadata);
-				final ClassDesc[] treeOwners = createMethodPerEnsemble(classBuilder, stratum, thisClass, innerClassBytes);
+				final ClassDesc[] treeOwners = createMethodPerEnsemble(classBuilder, stratum, thisClass, innerClasses);
 				implementRegressorPredictMethod(classBuilder, stratum, treeOwners);
 			});
 
-			for (final byte[] innerBytes : innerClassBytes) {
-				lookup.defineClass(innerBytes);
+			for (final CompiledModel innerClass : innerClasses) {
+				defineInnerClass(lookup, innerClass);
 			}
-			final RegressionFossil fossil = defineFossil(lookup, fossilBytes, RegressionFossil.class);
+			final CompiledModel fossilClass = new CompiledModel(thisClass.displayName(), fossilBytes);
+			final RegressionFossil fossil = defineFossil(lookup, fossilClass, RegressionFossil.class);
 			return fossil;
 		} catch (final Exception e) {
 			throw new UnexpectedCometImpact(e);
@@ -159,7 +161,8 @@ public class Petrify {
 				implementLinearClassifierPredictMethod(classBuilder, vine);
 			});
 
-			final ClassifierFossil fossil = defineFossil(lookup, fossilBytes, ClassifierFossil.class);
+			final ClassifierFossil fossil = defineFossil(lookup, new CompiledModel(thisClass.displayName(), fossilBytes),
+					ClassifierFossil.class);
 			return fossil;
 		} catch (final Exception e) {
 			throw new UnexpectedCometImpact(e);
@@ -183,7 +186,8 @@ public class Petrify {
 				implementLinearRegressorPredictMethod(classBuilder, vine);
 			});
 
-			final RegressionFossil fossil = defineFossil(lookup, fossilBytes, RegressionFossil.class);
+			final RegressionFossil fossil = defineFossil(lookup, new CompiledModel(thisClass.displayName(), fossilBytes),
+					RegressionFossil.class);
 			return fossil;
 		} catch (final Exception e) {
 			throw new UnexpectedCometImpact(e);
@@ -460,7 +464,7 @@ public class Petrify {
 	}
 
 	protected ClassDesc[] createMethodPerEnsemble(final ClassBuilder classBuilder, final Stratum stratum, final ClassDesc thisClass,
-			final List<byte[]> innerClassBytes) {
+			final List<CompiledModel> innerClasses) {
 		final ByteCodeAdapter adapter = getByteCodeAdapter(stratum.grove.precisionMode);
 		final MethodTypeDesc treeMethodDesc = MethodTypeDesc.of(ConstantDescs.CD_void, adapter.arrayDesc(), adapter.arrayDesc());
 		final int[] treeRootIds = stratum.treeRootIds;
@@ -495,7 +499,7 @@ public class Petrify {
 					treeIdxHolder[0]++;
 				}
 			});
-			innerClassBytes.add(innerBytes);
+			innerClasses.add(new CompiledModel(innerClassDesc.displayName(), innerBytes));
 			innerClassCounter++;
 		}
 		log.info("createMethodPerEnsemble() trees:{} innerClasses:{}", treeRootIds.length, innerClassCounter);
@@ -738,11 +742,15 @@ public class Petrify {
 	}
 
 	@SuppressWarnings("unchecked")
-	protected <T extends Fossil> T defineFossil(final MethodHandles.Lookup lookup, final byte[] fossilBytes, final Class<T> fossilType)
-			throws Exception {
-		final Class<?> clazz = lookup.defineClass(fossilBytes);
+	protected <T extends Fossil> T defineFossil(final MethodHandles.Lookup lookup, final CompiledModel compiledClass,
+			final Class<T> fossilType) throws Exception {
+		final Class<?> clazz = lookup.defineClass(compiledClass.classBytes());
 		final T fossil = (T) clazz.getDeclaredConstructor().newInstance();
 		return fossil;
+	}
+
+	protected void defineInnerClass(final MethodHandles.Lookup lookup, final CompiledModel compiledClass) throws Exception {
+		lookup.defineClass(compiledClass.classBytes());
 	}
 
 	protected void setJdk(final ClassBuilder classBuilder) {

--- a/petrify/src/main/java/com/github/exabrial/petrify/Petrify.java
+++ b/petrify/src/main/java/com/github/exabrial/petrify/Petrify.java
@@ -60,10 +60,23 @@ public class Petrify {
 	protected static final int TREE_SLOT_SCORES = 1;
 	protected static final String TREE_METHOD_PREFIX = "tree_";
 
+	protected static final int CP_ENTRIES_PER_CROSS_CLASS_INVOCATION = 5;
+	public static final int DEFAULT_CONSTANT_POOL_SOFT_MAX = 55000;
+
 	private static final ByteCodeAdapter SINGLE_PRECISION_ADAPTER = new SinglePrecisionByteCodeAdapter();
 	private static final ByteCodeAdapter DOUBLE_PRECISION_ADAPTER = new DoublePrecisionByteCodeAdapter();
 
+	private int constantPoolSoftMax = DEFAULT_CONSTANT_POOL_SOFT_MAX;
+
 	protected static int counter = 0;
+
+	public void setConstantPoolSoftMax(final int constantPoolSoftMax) {
+		this.constantPoolSoftMax = constantPoolSoftMax;
+	}
+
+	protected int getConstantPoolSoftMax() {
+		return constantPoolSoftMax;
+	}
 
 	public ClassifierFossil fossilize(final MethodHandles.Lookup lookup, final ClassifierGrove grove) {
 		log.info("fossilize() compiling ClassifierGrove classes:{} precisionMode:{} summary:{} ", grove.classLabelsInt64s.length,

--- a/petrify/src/main/java/com/github/exabrial/petrify/Petrify.java
+++ b/petrify/src/main/java/com/github/exabrial/petrify/Petrify.java
@@ -453,11 +453,25 @@ public class Petrify {
 		final ByteCodeAdapter adapter = getByteCodeAdapter(stratum.grove.precisionMode);
 		final MethodTypeDesc treeMethodDesc = MethodTypeDesc.of(ConstantDescs.CD_void, adapter.arrayDesc(), adapter.arrayDesc());
 		final ClassDesc[] treeOwners = new ClassDesc[stratum.treeRootIds.length];
-		for (int i = 0; i < stratum.treeRootIds.length; i++) {
-			final int treeId = stratum.treeRootIds[i];
-			final int rootArrayIdx = stratum.nodeIndex.get(PetrifyConstants.packLong(treeId, 0));
-			emitTreeMethod(classBuilder, treeMethodDesc, stratum, treeId, rootArrayIdx);
-			treeOwners[i] = thisClass;
+		int treeIdx = 0;
+		// Fossil phase: pack trees onto the fossil class, reserving CP headroom for cross-class invocations
+		while (treeIdx < stratum.treeRootIds.length) {
+			final int remainingTrees = stratum.treeRootIds.length - treeIdx;
+			final int projectedCpUsage = classBuilder.constantPool().size() + remainingTrees * CP_ENTRIES_PER_CROSS_CLASS_INVOCATION;
+			if (projectedCpUsage >= constantPoolSoftMax) {
+				log.debug("createMethodPerEnsemble() fossil spill at tree index:{}, constantPoolSize:{} remainingTrees:{}", treeIdx,
+						classBuilder.constantPool().size(), remainingTrees);
+				break;
+			} else {
+				final int treeId = stratum.treeRootIds[treeIdx];
+				final int rootArrayIdx = stratum.nodeIndex.get(PetrifyConstants.packLong(treeId, 0));
+				emitTreeMethod(classBuilder, treeMethodDesc, stratum, treeId, rootArrayIdx);
+				treeOwners[treeIdx] = thisClass;
+				treeIdx++;
+			}
+		}
+		if (treeIdx < stratum.treeRootIds.length) {
+			// TODO: inner class phase (step 4) — remaining trees at index i..treeRootIds.length
 		}
 		return treeOwners;
 	}

--- a/petrify/src/main/java/com/github/exabrial/petrify/Petrify.java
+++ b/petrify/src/main/java/com/github/exabrial/petrify/Petrify.java
@@ -94,8 +94,8 @@ public class Petrify {
 				createSerialVersionUid(classBuilder);
 				createDefaultConstructor(classBuilder);
 				emitMetadataMethods(classBuilder, grove.metadata);
-				createMethodPerEnsemble(classBuilder, stratum);
-				implementClassifierPredictMethod(classBuilder, stratum, thisClass);
+				final ClassDesc[] treeOwners = createMethodPerEnsemble(classBuilder, stratum, thisClass);
+				implementClassifierPredictMethod(classBuilder, stratum, treeOwners);
 			});
 
 			final ClassifierFossil fossil = defineFossil(lookup, fossilBytes, ClassifierFossil.class);
@@ -121,8 +121,8 @@ public class Petrify {
 				createSerialVersionUid(classBuilder);
 				createDefaultConstructor(classBuilder);
 				emitMetadataMethods(classBuilder, grove.metadata);
-				createMethodPerEnsemble(classBuilder, stratum);
-				implementRegressorPredictMethod(classBuilder, stratum, thisClass);
+				final ClassDesc[] treeOwners = createMethodPerEnsemble(classBuilder, stratum, thisClass);
+				implementRegressorPredictMethod(classBuilder, stratum, treeOwners);
 			});
 
 			final RegressionFossil fossil = defineFossil(lookup, fossilBytes, RegressionFossil.class);
@@ -284,7 +284,7 @@ public class Petrify {
 	}
 
 	protected void implementClassifierPredictMethod(final ClassBuilder classBuilder, final ClassifierStratum stratum,
-			final ClassDesc thisClass) {
+			final ClassDesc[] treeOwners) {
 		final ByteCodeAdapter adapter = getByteCodeAdapter(stratum.grove.precisionMode);
 		final MethodTypeDesc treeMethodDesc = MethodTypeDesc.of(ConstantDescs.CD_void, adapter.arrayDesc(), adapter.arrayDesc());
 
@@ -295,8 +295,8 @@ public class Petrify {
 					codeBuilder.newarray(adapter.typeKind());
 					codeBuilder.astore(PREDICT_SLOT_SCORES);
 
-					// Invoke each tree method: this.tree_N(features, scores)
-					emitTreeInvocations(codeBuilder, stratum, thisClass, treeMethodDesc);
+					// Invoke each tree method
+					emitTreeInvocations(codeBuilder, stratum, treeOwners, treeMethodDesc);
 
 					// Apply per-class bias before post-transform
 					emitBaseValues(codeBuilder, stratum.grove.baseValues, adapter);
@@ -321,7 +321,7 @@ public class Petrify {
 	}
 
 	protected void implementRegressorPredictMethod(final ClassBuilder classBuilder, final RegressorStratum stratum,
-			final ClassDesc thisClass) {
+			final ClassDesc[] treeOwners) {
 		final ByteCodeAdapter adapter = getByteCodeAdapter(stratum.grove.precisionMode);
 		final MethodTypeDesc treeMethodDesc = MethodTypeDesc.of(ConstantDescs.CD_void, adapter.arrayDesc(), adapter.arrayDesc());
 
@@ -332,8 +332,8 @@ public class Petrify {
 					codeBuilder.newarray(adapter.typeKind());
 					codeBuilder.astore(PREDICT_SLOT_SCORES);
 
-					// Invoke each tree method: this.tree_N(features, scores)
-					emitTreeInvocations(codeBuilder, stratum, thisClass, treeMethodDesc);
+					// Invoke each tree method
+					emitTreeInvocations(codeBuilder, stratum, treeOwners, treeMethodDesc);
 
 					// Apply base values bias
 					emitBaseValues(codeBuilder, stratum.grove.baseValues, adapter);
@@ -449,21 +449,25 @@ public class Petrify {
 		}
 	}
 
-	protected void createMethodPerEnsemble(final ClassBuilder classBuilder, final Stratum stratum) {
+	protected ClassDesc[] createMethodPerEnsemble(final ClassBuilder classBuilder, final Stratum stratum, final ClassDesc thisClass) {
 		final ByteCodeAdapter adapter = getByteCodeAdapter(stratum.grove.precisionMode);
 		final MethodTypeDesc treeMethodDesc = MethodTypeDesc.of(ConstantDescs.CD_void, adapter.arrayDesc(), adapter.arrayDesc());
-		for (final int treeId : stratum.treeRootIds) {
+		final ClassDesc[] treeOwners = new ClassDesc[stratum.treeRootIds.length];
+		for (int i = 0; i < stratum.treeRootIds.length; i++) {
+			final int treeId = stratum.treeRootIds[i];
 			final int rootArrayIdx = stratum.nodeIndex.get(PetrifyConstants.packLong(treeId, 0));
 			emitTreeMethod(classBuilder, treeMethodDesc, stratum, treeId, rootArrayIdx);
+			treeOwners[i] = thisClass;
 		}
+		return treeOwners;
 	}
 
-	protected void emitTreeInvocations(final CodeBuilder codeBuilder, final Stratum stratum, final ClassDesc thisClass,
+	protected void emitTreeInvocations(final CodeBuilder codeBuilder, final Stratum stratum, final ClassDesc[] treeOwners,
 			final MethodTypeDesc treeMethodDesc) {
-		for (final int treeId : stratum.treeRootIds) {
+		for (int i = 0; i < stratum.treeRootIds.length; i++) {
 			codeBuilder.aload(PREDICT_SLOT_FEATURES);
 			codeBuilder.aload(PREDICT_SLOT_SCORES);
-			codeBuilder.invokestatic(thisClass, TREE_METHOD_PREFIX + treeId, treeMethodDesc);
+			codeBuilder.invokestatic(treeOwners[i], TREE_METHOD_PREFIX + stratum.treeRootIds[i], treeMethodDesc);
 		}
 	}
 


### PR DESCRIPTION
Close #22 - large models busting the constant pool

this was a doozy. Try to pack as many tree methods as possible into the mail Fossil, but keep an eye on the constant pool size. After we start to exceed a safe level, define a static inner class and keep packing trees. Save off defining all of these classes until the end to avoid a potential classloader leak (although this is unlikely).